### PR TITLE
chore: add github ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  build:
+    name: Lint, build, test, and build benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: cargo clippy --all-targets --all-features
+      - run: cargo build
+      - run: cargo test
+      - run: cargo bench --no-run


### PR DESCRIPTION
This avoids running the benchmarks because these should either be configured to run from a different github script and uploaded or only ran locally.