### PR TITLE
chore(release): exclude non-crate files from the published package (4.0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ comparison/gotree/time/*
 *.csv
 *.png
 *.eps
+
+# Output written by the phylogenetic-diversity example when it is run.
+/examples/phylogenetic-diversity/pds.out

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylo"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 rust-version = "1.87"
 
@@ -14,6 +14,22 @@ description = "An extensible Phylogenetics library written in rust"
 
 keywords = ["bioinformatics", "phylogenetics"]
 categories = ["data-structures", "science"]
+
+# Keep files that are not part of the crate out of the published package.
+exclude = [
+    # Claude Code project files: developer tooling, not library content.
+    "/CLAUDE.md",
+    "/.claude",
+    # Benchmark harness for comparing against other tools -- data dumps, other
+    # tools' binaries, a git submodule. Over 1300 files, none of them the crate.
+    "/comparison",
+    # Repository and CI plumbing, useful only when developing phylo itself.
+    "/.github",
+    "/.gitignore",
+    "/.git-blame-ignore-revs",
+    # Its only entry lived under comparison/, so it now points at nothing shipped.
+    "/.gitmodules",
+]
 
 [lib]
 name = "phylo"


### PR DESCRIPTION
## Summary

The published package ships far more than the library. **4.0.0** included `CLAUDE.md` and the entire `comparison/` benchmark harness — over 1,300 files of other tools' binaries, git submodules, and data dumps. This trims the package down to the crate.

**Package: 1,431 → 80 files (148.5 KiB compressed).** `cargo package` verifies the tarball builds.

## Excluded

| excluded | why |
|---|---|
| `/CLAUDE.md`, `/.claude` | Claude Code project files — developer tooling, not library content |
| `/comparison` | benchmark harness: other tools' binaries, a git submodule, data dumps (~1,300 files) |
| `/.github` | CI, issue templates, CODEOWNERS — repo plumbing |
| `/.gitmodules` | its only entry referenced a submodule under `comparison/`, so it now points at nothing shipped |
| `/.gitignore`, `/.git-blame-ignore-revs` | git tooling, no value to a crate consumer |

Also gitignores `examples/phylogenetic-diversity/pds.out` — the phylogenetic-diversity example writes it, and because the crate is published from a local checkout, that stray output was being swept into the package as an untracked file. Ignoring it fixes the repo and the package at once.

## Kept on purpose

`examples/**/trees/` and `sample-trees.trees` are **required data** — the examples `read_dir`/`read_to_string` them at runtime, verified. `src/`, `tests/`, `benches/`, README/LICENSE/CONTRIBUTING/CoC all belong.

## Version

Bumped to **4.0.1**. This is packaging-only — no source, no public API, no compiled behaviour changes; the diff is the `exclude` list plus one gitignore line. The bump is not optional regardless of semver level: crates.io does not allow re-publishing `4.0.0`, so a leaner tarball can only go out under a new version.

Independent of the in-flight `perf/arena-struct-overhaul` (5.0.0) work — this can ship standalone.

## Test plan

- [x] `cargo package` verifies the tarball builds (80 files, 148.5 KiB compressed)
- [x] `cargo package --list` shows no repo tooling, benchmark harness, or generated output
- [x] Example data files (`trees/`, `sample-trees.trees`) confirmed retained