### PR TITLE
feat: TreeLikelihood trait for pruning-only log-likelihood

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phylo"
-version = "5.0.0"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.87"
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ implement one.
   immutably and answers LCA queries in O(1) via an Euler tour + RMQ.
 - **Tree comparison** — Robinson-Foulds, weighted RF, cluster affinity, and
   cophenetic distance, with distance-matrix builders.
+- **Maximum-likelihood modeling** — GTR+I+G substitution models (JC69 through
+  GTR), Felsenstein-pruning log-likelihood, and marginal/joint ancestral
+  sequence reconstruction.
 - **I/O** — Newick and Nexus parsing and serialization.
 - **Simulation** — random trees (Yule, uniform).
 - **Optional parallelism** — opt into `rayon`-backed computation with the
@@ -59,8 +62,8 @@ phylo = "5"
 
 | Feature | Default | Description |
 | --- | :---: | --- |
-| `simple_rooted_tree` | ✅ | The concrete `SimpleRootedTree` / `PhyloTree` implementation. |
-| `non_crypto_hash` | ✅ | Use `fxhash` maps/sets instead of `std` for speed. |
+| `simple_rooted_tree` | Yes | The concrete `SimpleRootedTree` / `PhyloTree` implementation. |
+| `non_crypto_hash` | Yes | Use `fxhash` maps/sets instead of `std` for speed. |
 | `parallel` | | `rayon`-based parallel computation for the heavy metrics. |
 | `serde` | | `Serialize`/`Deserialize` for trees. |
 
@@ -148,6 +151,36 @@ let cluster_affinity = tree_1.ca(&tree_2);
 let cophenetic = tree_1.cophen_dist(&tree_2, 2);
 ```
 
+### Likelihood and ancestral reconstruction
+
+Score an alignment against a tree under a substitution model, or reconstruct
+ancestral sequences at the internal nodes. `log_likelihood` runs Felsenstein's
+pruning algorithm alone (no reconstruction); `marginal_asr` / `joint_asr` build
+on the same pruning core:
+
+```rust
+use phylo::prelude::*;
+
+let tree = PhyloTree::from_newick("((A:0.1,B:0.2):0.15,(C:0.3,D:0.1):0.05);".as_bytes()).unwrap();
+
+// A nucleotide alignment in FASTA — one sequence per leaf taxon.
+let fasta = b">A\nACGTACGT\n>B\nACGTATGT\n>C\nACGAACGT\n>D\nTCGTACGA\n";
+let aln = Alignment::from_fasta_bytes(fasta).unwrap();
+
+// HKY85 with gamma-distributed rate heterogeneity (+G, 4 categories).
+let model = GtrModel::<Nucleotide>::hky85([0.25, 0.25, 0.25, 0.25], 2.0)
+    .unwrap()
+    .with_gamma(0.5, 4)
+    .unwrap();
+
+// Log-likelihood of the alignment given the tree and model (pruning only).
+let log_lik = tree.log_likelihood::<Nucleotide>(&model, &aln).unwrap();
+
+// Marginal ancestral sequence reconstruction fills the internal nodes.
+let recon = tree.marginal_asr::<Nucleotide>(&model, &aln, false).unwrap();
+let root_sequence = recon.sequence_string(tree.get_root_id());
+```
+
 ## Module map
 
 | Module | What it does |
@@ -158,6 +191,9 @@ let cophenetic = tree_1.cophen_dist(&tree_2, 2);
 | [`tree::io`](https://docs.rs/phylo/latest/phylo/tree/io/) | Newick and Nexus reading/writing. |
 | [`tree::simulation`](https://docs.rs/phylo/latest/phylo/tree/simulation/) | Random tree generation. |
 | [`iter`](https://docs.rs/phylo/latest/phylo/iter/) | Traversals, Euler walks, and the LCA oracle. |
+| [`models`](https://docs.rs/phylo/latest/phylo/models/) | GTR+I+G substitution models and their named special cases. |
+| [`tree::likelihood`](https://docs.rs/phylo/latest/phylo/tree/likelihood/) | Felsenstein-pruning log-likelihood. |
+| [`tree::asr`](https://docs.rs/phylo/latest/phylo/tree/asr/) | Marginal and joint ancestral sequence reconstruction. |
 
 ## Examples
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,175 +1,212 @@
 #![warn(missing_docs)]
 
-//! The phylo crate aims to be useful when dealing with phylogenetic trees and analysis.
-//! It can be used to build such trees or read then from newick files, and perform phylogenetic anaysis.
+//! A fast, extensible, WebAssembly-ready phylogenetics library for Rust.
 //!
-//! # A note on implementation
+//! `phylo` provides memory-efficient data structures and algorithms for
+//! phylogenetic analysis and inference — from tree manipulation (SPR, NNI,
+//! rerooting) to tree statistics (phylogenetic diversity, RF distance, cophenetic
+//! distance) to maximum-likelihood modelling (GTR+I+G substitution models,
+//! Felsenstein pruning, ancestral reconstruction). It leans on Rust's memory
+//! safety, speed, and native WebAssembly support to stay both fast and portable.
 //!
-//! Implementation of tree-like structures in rust can be difficult and time-intensive. Additionally implementing
-//! tree traversals and operations on tree structures (recursive or otherwise) can be an even bigger task.
+//! Tree traversals and operations are exposed as **derivable traits**, so you get
+//! DFS/BFS/pre-/post-order, Euler tours, LCA queries, and distance metrics for
+//! free on your own types — and a ready-made [`PhyloTree`](crate::tree::PhyloTree)
+//! when you don't want to implement one.
 //!
-//! This crate aims to implement a majority of such methods as easily-derivable traits, so you don't have to implement them from scratch where they are not needed.
-//!   
-//! **We also provide a struct so you don't have to implement one...**  
+//! # Highlights
 //!
-//! # Using `phylo`
-//! Most of the functionality is implemented in [`crate::tree::simple_rtree`]. The
-//! [`crate::tree::ops`] module is used to dealt with phylolgenetic analysis that require tree mutations such as SPR, NNI, etc.
-//! [`crate::tree::simulation`] module is used to simulate random trees
-//! [`crate::tree::io`] module is used to read trees from various encodings
-//! [`crate::tree::distances`] module is used to compute various types of distance between nodes in a tree and between trees
-//! [`crate::iter`] is a helper module to provide tree traversals and iterations.
+//! - **Trait-first design** — compose narrow traits (`RootedTree`,
+//!   `RootedMetaTree`, `EulerWalk`, `DFS`, `Clusters`, …) onto any type, or use
+//!   the batteries-included [`PhyloTree`](crate::tree::PhyloTree).
+//! - **Arena-allocated trees** — cache-friendly `Vec`-backed storage with `usize`
+//!   node IDs.
+//! - **Constant-time LCA** — an [`LcaOracle`](crate::iter::lca::LcaOracle) borrows
+//!   the tree immutably and answers LCA queries in O(1) via an Euler tour + RMQ.
+//! - **Tree comparison** — Robinson-Foulds, weighted RF, cluster affinity, and
+//!   cophenetic distance, with distance-matrix builders.
+//! - **Maximum-likelihood modelling** — GTR+I+G substitution models (JC69 through
+//!   GTR), Felsenstein-pruning log-likelihood, and marginal/joint ancestral
+//!   sequence reconstruction.
+//! - **I/O** — Newick and Nexus parsing and serialization.
+//! - **Simulation** — random trees (Yule, uniform).
+//! - **Optional parallelism** — opt into `rayon`-backed computation with the
+//!   `parallel` feature.
 //!
-//! ## Building trees
-//! The simplest way to build a tree is to create an empty tree, add a root node and
-//! then add children to the various added nodes:
+//! # Feature flags
+//!
+//! | Feature | Default | Description |
+//! | --- | :---: | --- |
+//! | `simple_rooted_tree` | Yes | The concrete `SimpleRootedTree` / `PhyloTree` implementation. |
+//! | `non_crypto_hash` | Yes | Use `fxhash` maps/sets instead of `std` for speed. |
+//! | `parallel` | | `rayon`-based parallel computation for the heavy metrics. |
+//! | `serde` | | `Serialize`/`Deserialize` for trees. |
+//!
+//! # Quick start
+//!
+//! Everything you need is in the prelude:
+//!
+//! ```
+//! use phylo::prelude::*;
+//! ```
+//!
+//! ## Build a tree
+//!
+//! Create an empty tree, then attach children to node IDs:
 //!
 //! ```
 //! use phylo::prelude::*;
 //!
 //! let mut tree = PhyloTree::new(1);
 //!
-//! let new_node = PhyloNode::new(2);
-//! tree.add_child(tree.get_root_id(), new_node);
-//! let new_node = PhyloNode::new(3);
-//! tree.add_child(tree.get_root_id(), new_node);
-//! let new_node: PhyloNode = PhyloNode::new(4);
-//! tree.add_child(2, new_node);
-//! let new_node: PhyloNode = PhyloNode::new(5);
-//! tree.add_child(2, new_node);
+//! tree.add_child(tree.get_root_id(), PhyloNode::new(2));
+//! tree.add_child(tree.get_root_id(), PhyloNode::new(3));
+//! tree.add_child(2, PhyloNode::new(4));
+//! tree.add_child(2, PhyloNode::new(5));
 //! ```
 //!
-//! ## Reading and writing trees
-//! This library can build trees strings (or files) encoded in the
-//! [newick](https://en.wikipedia.org/wiki/Newick_format) format:
+//! ## Read and write Newick
+//!
 //! ```
 //! use phylo::prelude::*;
 //!
-//! let input_str = String::from("((A:0.1,B:0.2),C:0.6);");
-//! let tree = PhyloTree::from_newick(input_str.as_bytes()).unwrap();
+//! let tree = PhyloTree::from_newick("((A:0.1,B:0.2),C:0.6);".as_bytes()).unwrap();
+//! let newick = tree.to_newick();
 //! ```
 //!
-//! ## Traversing trees
-//! Several traversals are implemented to visit nodes in a particular order. pre-order,
-//! post-order. A traversals returns an [`Iterator`] of either nodes or PhyloNodeID's
-//! in the order they are to be visited in.
+//! ## Traverse
+//!
+//! Traversals return an [`Iterator`] of nodes or node IDs in visiting order:
+//!
 //! ```
 //! use phylo::prelude::*;
 //!
-//! let input_str = String::from("((A:0.1,B:0.2),C:0.6);");
-//! let tree = PhyloTree::from_newick(input_str.as_bytes()).unwrap();
+//! let tree = PhyloTree::from_newick("((A:0.1,B:0.2),C:0.6);".as_bytes()).unwrap();
 //!
-//! let dfs_traversal = tree.dfs(tree.get_root_id()).into_iter();
-//! let bfs_traversal = tree.bfs_ids(tree.get_root_id());
-//! let postfix_traversal = tree.postord_ids(tree.get_root_id());
+//! let dfs = tree.dfs(tree.get_root_id());
+//! let bfs = tree.bfs_ids(tree.get_root_id());
+//! let postorder = tree.postord_ids(tree.get_root_id());
 //! ```
 //!
+//! ## Constant-time LCA
 //!
-//! ## Comparing trees
-//! A number of metrics taking into account topology and branch lenghts are implemented
-//! in order to compare trees with each other:
+//! Build an [`LcaOracle`](crate::iter::lca::LcaOracle) with `tree.lca()`; it
+//! borrows the tree immutably (so staleness is a compile error, not a runtime bug)
+//! and answers queries in O(1):
+//!
+//! ```
+//! use phylo::prelude::*;
+//!
+//! let tree = PhyloTree::from_newick("((A,B),(C,D));".as_bytes()).unwrap();
+//!
+//! let a = tree.get_taxa_node_id(&"A".to_string()).unwrap();
+//! let b = tree.get_taxa_node_id(&"B".to_string()).unwrap();
+//!
+//! let lca = tree.lca();
+//! let ancestor = lca.get_lca_id(&[a, b]);
+//! ```
+//!
+//! ## Compare trees
+//!
+//! Metrics account for both topology and branch lengths:
+//!
 //! ```
 //! use phylo::prelude::*;
 //!
 //! fn depth(tree: &PhyloTree, node_id: usize) -> f32 {
 //!     tree.depth(node_id) as f32
 //! }
-
-//! let newick_1 = "((A:0.1,B:0.2):0.6,(C:0.3,D:0.4):0.5);";
-//! let newick_2 = "((D:0.3,C:0.4):0.5,(B:0.2,A:0.1):0.6);";
 //!
-//! let mut tree_1 = PhyloTree::from_newick(newick_1.as_bytes()).unwrap();
-//! let mut tree_2 = PhyloTree::from_newick(newick_2.as_bytes()).unwrap();
+//! let mut tree_1 = PhyloTree::from_newick("((A:0.1,B:0.2):0.6,(C:0.3,D:0.4):0.5);".as_bytes()).unwrap();
+//! let mut tree_2 = PhyloTree::from_newick("((D:0.3,C:0.4):0.5,(B:0.2,A:0.1):0.6);".as_bytes()).unwrap();
 //!
-//! tree_1.set_zeta(depth);
-//! tree_2.set_zeta(depth);
+//! let _ = tree_1.set_zeta(depth);
+//! let _ = tree_2.set_zeta(depth);
 //!
-//!
-//! let ca = tree_1.ca(&tree_2);
-//! let cophen = tree_1.cophen_dist(&tree_2, 2);
+//! let cluster_affinity = tree_1.ca(&tree_2);
+//! let cophenetic = tree_1.cophen_dist(&tree_2, 2);
 //! ```
+//!
+//! ## Likelihood and ancestral reconstruction
+//!
+//! Score an alignment against a tree under a substitution model, or reconstruct
+//! ancestral sequences at the internal nodes. The log-likelihood path
+//! ([`TreeLikelihood`](crate::tree::likelihood::TreeLikelihood)) runs Felsenstein's
+//! pruning algorithm alone — no reconstruction — while marginal/joint ASR
+//! ([`MarginalAsr`](crate::tree::asr::MarginalAsr) /
+//! [`JointAsr`](crate::tree::asr::JointAsr)) build on the same pruning core:
+//!
+//! ```
+//! use phylo::prelude::*;
+//!
+//! let tree =
+//!     PhyloTree::from_newick("((A:0.1,B:0.2):0.15,(C:0.3,D:0.1):0.05);".as_bytes()).unwrap();
+//!
+//! // A nucleotide alignment in FASTA — one sequence per leaf taxon.
+//! let fasta = b">A\nACGTACGT\n>B\nACGTATGT\n>C\nACGAACGT\n>D\nTCGTACGA\n";
+//! let aln = Alignment::from_fasta_bytes(fasta).unwrap();
+//!
+//! // HKY85 with gamma-distributed rate heterogeneity (+G, 4 categories).
+//! let model = GtrModel::<Nucleotide>::hky85([0.25, 0.25, 0.25, 0.25], 2.0)
+//!     .unwrap()
+//!     .with_gamma(0.5, 4)
+//!     .unwrap();
+//!
+//! // Log-likelihood of the alignment given the tree and model (pruning only).
+//! let log_lik = tree.log_likelihood::<Nucleotide>(&model, &aln).unwrap();
+//! assert!(log_lik.is_finite());
+//!
+//! // Marginal ancestral sequence reconstruction fills the internal nodes.
+//! let recon = tree.marginal_asr::<Nucleotide>(&model, &aln, false).unwrap();
+//! let root_sequence = recon.sequence_string(tree.get_root_id());
+//! ```
+//!
+//! # Module map
+//!
+//! | Module | What it does |
+//! | --- | --- |
+//! | [`tree::simple_rtree`] | Core tree traits and `SimpleRootedTree`. |
+//! | [`tree::ops`] | Mutating operations: SPR, NNI, reroot, contraction, subtree extraction. |
+//! | [`tree::distances`] | RF, weighted RF, cluster affinity, cophenetic distance, distance matrices. |
+//! | [`tree::io`] | Newick and Nexus reading/writing. |
+//! | [`tree::simulation`] | Random tree generation. |
+//! | [`iter`] | Traversals, Euler walks, and the LCA oracle. |
+//! | [`models`] | GTR+I+G substitution models and their named special cases. |
+//! | [`tree::likelihood`] | Felsenstein-pruning log-likelihood. |
+//! | [`tree::asr`] | Marginal and joint ancestral sequence reconstruction. |
 //!
 //! # Examples
-//! The following snippets are code examples of some phylogenetic analyses. You can find these in the `examples` directory of the repository
 //!
-//! ## Quantifying Phylogenetic Diversity
-//! Quantifying the Phylogenetic Diveristy of a set of trees using the Faith Index:
-//! ```ignore
-//! #[cfg(feature = "non_crypto_hash")]
-//! use fxhash::FxHashMap as HashMap;
-//! #[cfg(not(feature = "non_crypto_hash"))]
-//! use std::collections::HashMap;
+//! Runnable analyses live in the `examples/` directory of the repository (e.g.
+//! `cargo run --example phylogenetic-diversity`, `cargo run --example
+//! pairwise-distances`). See the repository README for how to visualize their
+//! output.
 //!
-//! use itertools::Itertools;
-//! use std::fs::{File, read_to_string};
-//! use phylo::prelude::*;
-//! use std::io::Write;
+//! # WebAssembly
 //!
-//! fn main() {
-//!     let paths: HashMap<_, _> = std::fs::read_dir("examples/phylogenetic-diversity/trees")
-//!        .unwrap()
-//!        .map(|x| (x.as_ref().unwrap().file_name().into_string().unwrap(), std::fs::read_dir(x.unwrap().path()).unwrap()
-//!            .map(|f| (f.as_ref().unwrap().file_name().into_string().unwrap().split("-").map(|x| x.to_string()).collect_vec()[0].clone(), PhyloTree::from_newick(read_to_string(f.unwrap().path()).unwrap().as_bytes()).unwrap()))
-//!            .collect::<HashMap<_,_>>()))
-//!        .collect();
-//!        
-//!        for (clade, trees) in paths.iter(){
-//!        println!("Clade: {}", clade);
-//!        let mut pds = vec![];
-//!        for year in 2015..2023{
-//!            let tree = trees.get(&year.to_string());
-//!            match tree{
-//!                Some(t) => {
-//!                    println!("{}: {}", year, t.get_nodes().map(|n| n.get_weight().unwrap_or(0.0)).sum::<f32>());
-//!                    pds.push(t.get_nodes().map(|n| n.get_weight().unwrap_or(0.0)).sum::<f32>());
-//!                },
-//!                _ => {println!("{}: {}", year, 0.0); pds.push(0.0);},
-//!            };
-//!        }
-//!        }
-//! }
-//! ```
-//! ## Visualizing Phylogenetic Tree Space
-//! Here, we copmpute all pairwise RF distances of a set of trees:
-//! ```ignore
-//! #[cfg(feature = "non_crypto_hash")]
-//! use fxhash::FxHashMap as HashMap;
-//! #[cfg(not(feature = "non_crypto_hash"))]
-//! use std::collections::HashMap;
+//! `phylo` builds for `wasm32` targets out of the box, making it suitable for
+//! in-browser phylogenetics — use your usual wasm toolchain (e.g. `wasm-pack`, or
+//! `cargo build --target wasm32-unknown-unknown`).
 //!
-//! use itertools::Itertools;
-//! use std::fs::{File, read_to_string};
-//! use phylo::prelude::*;
-//! use std::io::Write;
-//! use indicatif::{ProgressIterator, ProgressBar, ProgressStyle};
+//! # Citation
 //!
-//! fn main() {
-//!     let trees = (1..11).progress().map(|x| read_to_string(format!("examples/pairwise-distances/sample-trees.trees"))
-//!             .unwrap()
-//!             .lines()
-//!             .enumerate()
-//!             .map(|(y,z)| (x,y,PhyloTree::from_newick(z.as_bytes()).unwrap()))
-//!             .collect_vec()
-//!         )
-//!         .flatten()
-//!         .collect_vec();
-//!     
-//!     
-//!     let bar = ProgressBar::new((trees.len()*(trees.len()-1)/2) as u64);
-//!     bar.set_style(ProgressStyle::with_template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg} [eta: {eta}]")
-//!         .unwrap()
-//!         .progress_chars("##-"));
-//!     
-//!     trees.iter().combinations(2).map(|v| (v[0], v[1])).for_each(|(x,y)| {
-//!         let out = format!("{}-{}-{}-{}-{}\n", x.0, y.0, x.1, y.1, x.2.ca(&y.2));
-//!         println!("{}", out);
-//!         bar.inc(1);
-//!     });
-//!     bar.finish();
+//! If you use `phylo` in your work, please cite
+//! [this paper](https://pmc.ncbi.nlm.nih.gov/articles/PMC12309125/):
+//!
+//! ```bibtex
+//! @article{vijendran2025phylo,
+//!   title={Phylo-rs: an extensible phylogenetic analysis library in rust},
+//!   author={Vijendran, Sriram and Anderson, Tavis and Markin, Alexey and Eulenstein, Oliver},
+//!   journal={BMC bioinformatics},
+//!   volume={26},
+//!   pages={197},
+//!   year={2025}
 //! }
 //! ```
 //!
+//! # License
 //!
+//! Licensed under the MIT License.
 
 /// Module with multiple sequence alignments and column compression.
 pub mod alignment;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,9 +1,9 @@
 //! Substitution models for molecular evolution.
 //!
-//! The base model is **GTR+I+G** ([`gtr::GtrModel`]): the General Time Reversible model
+//! The base model is **GTR+I+G** ([`GtrModel`](crate::models::gtr::GtrModel)): the General Time Reversible model
 //! with a proportion of invariant sites (+I) and discrete-gamma rate heterogeneity (+G).
 //! Every other named nucleotide model (JC69, K80, F81, HKY85, TN93, K81, TIM, TVM, SYM,
-//! GTR) is exposed as a special case via a named constructor on [`gtr::GtrModel`], per the
+//! GTR) is exposed as a special case via a named constructor on [`GtrModel`](crate::models::gtr::GtrModel), per the
 //! nested model hierarchy in Posada & Crandall (2001), Sysbio 50(4):580.
 
 /// Eigendecomposition-based rate matrix core shared by all substitution models.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -39,6 +39,7 @@ mod simple_rooted_tree {
     use std::collections::{HashMap, HashSet};
 
     use crate::tree::asr::{JointAsr, MarginalAsr};
+    use crate::tree::likelihood::TreeLikelihood;
 
     /// Type alias for Phylogenetic tree.
     pub type PhyloTree = SimpleRootedTree<String, f32, f32>;
@@ -61,6 +62,16 @@ mod simple_rooted_tree {
             aln: &Alignment,
         ) -> Result<Reconstruction<A>, AsrError> {
             crate::tree::likelihood::compute_joint_asr(self, model, aln)
+        }
+    }
+
+    impl TreeLikelihood for PhyloTree {
+        fn log_likelihood<A: Alphabet>(
+            &self,
+            model: &GtrModel<A>,
+            aln: &Alignment,
+        ) -> Result<f64, AsrError> {
+            crate::tree::likelihood::compute_log_likelihood(self, model, aln)
         }
     }
 

--- a/src/tree/likelihood.rs
+++ b/src/tree/likelihood.rs
@@ -1,14 +1,19 @@
 //! Phylogenetic likelihood under a substitution model.
 //!
 //! Felsenstein's pruning algorithm over a tree and an [`Alignment`], generalized
-//! across the rate categories of a [`GtrModel`]. Both engines here compute the
-//! tree's log-likelihood; ancestral state reconstruction (see [`crate::tree::asr`])
-//! is built on top of them.
+//! across the rate categories of a [`GtrModel`].
 //!
-//! Note the current seam: the engines return a [`Reconstruction`], so the
-//! log-likelihood is only reachable by also reconstructing states. Separating
-//! those requires making pruning reusable and generic over `RootedTree`, which
-//! is deliberately not done here.
+//! [`compute_log_likelihood`] returns just the tree's log-likelihood — the
+//! Felsenstein up pass, no ancestral states. [`compute_marginal_asr`] reuses the
+//! same per-pattern pruning core (`prune_pattern_category`) and adds a pre-order
+//! down pass to reconstruct states and posteriors, so the two never drift. The
+//! [`TreeLikelihood`] trait exposes the likelihood-only path.
+//!
+//! The joint (Viterbi) engine keeps its own recursion: it maximizes rather than
+//! sums over states (a different semiring), so it cannot share the marginal core.
+//!
+//! Making pruning generic over `RootedTree` (rather than concrete in `PhyloTree`)
+//! is a deliberate non-goal here.
 
 /// Likelihood profiles and scaling for numerical stability.
 pub mod profile;
@@ -20,6 +25,20 @@ pub mod reconstruction;
 mod integration_test;
 
 pub use self::reconstruction::Reconstruction;
+
+/// Log-likelihood of an alignment given a tree and a substitution model.
+///
+/// Feature-free (like [`crate::tree::asr::MarginalAsr`]) so a caller bringing its
+/// own tree type can implement it without `simple_rooted_tree`.
+pub trait TreeLikelihood {
+    /// Natural-log likelihood of `aln` given this tree and `model`, computed with
+    /// Felsenstein's pruning algorithm. No ancestral states are reconstructed.
+    fn log_likelihood<A: crate::alphabet::Alphabet>(
+        &self,
+        model: &crate::models::GtrModel<A>,
+        aln: &crate::alignment::Alignment,
+    ) -> Result<f64, crate::error::AsrError>;
+}
 
 // Every engine here is concrete in PhyloTree, so the module's imports gate as a
 // block. What stays available without the feature is `crate::tree::asr`, which
@@ -43,6 +62,144 @@ fn log_sum_exp(xs: &[f64]) -> f64 {
     }
     let sum: f64 = xs.iter().map(|&x| (x - max).exp()).sum();
     max + sum.ln()
+}
+
+/// Felsenstein's pruning up pass for a single compressed pattern under a single
+/// rate category.
+///
+/// Runs the rooted post-order traversal, building a scaled likelihood [`Profile`]
+/// at every node (branch lengths scaled by category `cat_idx`'s rate), and returns
+/// the profile map together with this category's log-likelihood contribution
+/// `ln(weight) + ln(root_mass) + root_log_scale`.
+///
+/// This is the shared core: [`compute_log_likelihood`] keeps only the returned
+/// `cat_ll` (dropping the profiles), while [`compute_marginal_asr`] retains the
+/// profiles to seed its down pass. There is exactly one pruning recursion.
+#[cfg(feature = "simple_rooted_tree")]
+#[allow(clippy::too_many_arguments)]
+fn prune_pattern_category<A: Alphabet>(
+    tree: &PhyloTree,
+    model: &GtrModel<A>,
+    cat_idx: usize,
+    category_weight: f64,
+    pattern: &[u8],
+    leaf_id_map: &[NodeID],
+    postord: &[NodeID],
+    pi: &DVector<f64>,
+    n_states: usize,
+) -> Result<(HashMap<NodeID, Profile>, f64), AsrError> {
+    let root = tree.get_root_id();
+    let mut profiles: HashMap<NodeID, Profile> = HashMap::new();
+
+    for v in postord {
+        if tree.is_leaf(*v) {
+            let pos = leaf_id_map.iter().position(|&id| id == *v).ok_or_else(|| {
+                AsrError::InvalidAlignment(
+                    "Leaf in tree not found in alignment leaf order".to_string(),
+                )
+            })?;
+            let char_val = pattern[pos];
+            let prof_vals = A::profile(char_val).ok_or_else(|| {
+                AsrError::AlphabetMismatch("Invalid char in alignment".to_string())
+            })?;
+            profiles.insert(*v, Profile::new(prof_vals, 0.0).scale());
+        } else {
+            let mut v_vals = DVector::from_element(n_states, 1.0);
+            let mut sum_log_scale = 0.0;
+
+            for c in tree.get_node_children_ids(*v) {
+                let prof_c = profiles.get(&c).ok_or(AsrError::NumericalInstability)?;
+                let weight = tree
+                    .get_edge_weight(*v, c)
+                    .and_then(NumCast::from)
+                    .unwrap_or(0.0);
+                let p_t = model.category_transition(cat_idx, weight);
+
+                let child_contrib = p_t * DVector::from_vec(prof_c.values.clone());
+
+                for i in 0..n_states {
+                    v_vals[i] *= child_contrib[i];
+                }
+                sum_log_scale += prof_c.log_scale;
+            }
+            profiles.insert(
+                *v,
+                Profile::new(v_vals.as_slice().to_vec(), sum_log_scale).scale(),
+            );
+        }
+    }
+
+    let root_prof = profiles.get(&root).ok_or(AsrError::NumericalInstability)?;
+    let mut root_mass = 0.0;
+    for i in 0..n_states {
+        root_mass += pi[i] * root_prof.values[i];
+    }
+    let cat_ll = category_weight.ln() + root_mass.ln() + root_prof.log_scale;
+
+    Ok((profiles, cat_ll))
+}
+
+/// Log-likelihood of an alignment given a tree and a substitution model.
+///
+/// Felsenstein's pruning up pass only: for each compressed alignment pattern the
+/// per-category log-likelihoods (`prune_pattern_category`) are mixed with
+/// [`log_sum_exp`] and accumulated by pattern multiplicity. No down pass, and no
+/// per-node sequence/posterior allocation — unlike [`compute_marginal_asr`], whose
+/// `log_likelihood` field this reproduces exactly.
+///
+/// Concrete in `PhyloTree`, so it is gated on the feature that defines it. The
+/// [`TreeLikelihood`] trait itself stays available without that feature.
+#[cfg(feature = "simple_rooted_tree")]
+pub fn compute_log_likelihood<A>(
+    tree: &PhyloTree,
+    model: &GtrModel<A>,
+    aln: &Alignment,
+) -> Result<f64, AsrError>
+where
+    A: Alphabet,
+{
+    let comp = aln.compress_columns();
+    let root = tree.get_root_id();
+    let n_states = A::N_STATES;
+    let pi = model.equilibrium();
+    let categories = model.categories();
+    let n_categories = categories.len();
+
+    // Map alignment leaf order to NodeIDs.
+    let mut leaf_id_map = Vec::with_capacity(comp.leaf_order.len());
+    for name in &comp.leaf_order {
+        let node_id = tree.get_taxa_node_id(name).ok_or_else(|| {
+            AsrError::AlphabetMismatch(format!("Taxon {} in alignment not found in tree", name))
+        })?;
+        leaf_id_map.push(node_id);
+    }
+
+    let postord = tree.postord_ids(root).collect::<Vec<_>>();
+
+    let mut total_log_likelihood = 0.0;
+    for (p_idx, pattern) in comp.patterns.iter().enumerate() {
+        let multiplicity = comp.multiplicity[p_idx] as f64;
+
+        let mut cat_log_likelihoods = Vec::with_capacity(n_categories);
+        for (cat_idx, category) in categories.iter().enumerate() {
+            let (_profiles, cat_ll) = prune_pattern_category(
+                tree,
+                model,
+                cat_idx,
+                category.weight,
+                pattern,
+                &leaf_id_map,
+                &postord,
+                pi,
+                n_states,
+            )?;
+            cat_log_likelihoods.push(cat_ll);
+        }
+
+        total_log_likelihood += multiplicity * log_sum_exp(&cat_log_likelihoods);
+    }
+
+    Ok(total_log_likelihood)
 }
 
 /// Internal implementation of Marginal ASR logic.
@@ -112,54 +269,21 @@ where
         let mut cat_posteriors: Vec<HashMap<NodeID, Vec<f64>>> = Vec::with_capacity(n_categories);
 
         for (cat_idx, category) in categories.iter().enumerate() {
-            // UP pass: Rooted post-order traversal
-            let mut profiles: HashMap<NodeID, Profile> = HashMap::new();
-
-            for v in &postord {
-                if tree.is_leaf(*v) {
-                    let pos = leaf_id_map.iter().position(|&id| id == *v).ok_or_else(|| {
-                        AsrError::InvalidAlignment(
-                            "Leaf in tree not found in alignment leaf order".to_string(),
-                        )
-                    })?;
-                    let char_val = pattern[pos];
-                    let prof_vals = A::profile(char_val).ok_or_else(|| {
-                        AsrError::AlphabetMismatch("Invalid char in alignment".to_string())
-                    })?;
-                    profiles.insert(*v, Profile::new(prof_vals, 0.0).scale());
-                } else {
-                    let mut v_vals = DVector::from_element(n_states, 1.0);
-                    let mut sum_log_scale = 0.0;
-
-                    for c in tree.get_node_children_ids(*v) {
-                        let prof_c = profiles.get(&c).ok_or(AsrError::NumericalInstability)?;
-                        let weight = tree
-                            .get_edge_weight(*v, c)
-                            .and_then(NumCast::from)
-                            .unwrap_or(0.0);
-                        let p_t = model.category_transition(cat_idx, weight);
-
-                        let child_contrib = p_t * DVector::from_vec(prof_c.values.clone());
-
-                        for i in 0..n_states {
-                            v_vals[i] *= child_contrib[i];
-                        }
-                        sum_log_scale += prof_c.log_scale;
-                    }
-                    profiles.insert(
-                        *v,
-                        Profile::new(v_vals.as_slice().to_vec(), sum_log_scale).scale(),
-                    );
-                }
-            }
-
-            let root_prof = profiles.get(&root).unwrap();
-            let mut root_mass = 0.0;
-            for i in 0..n_states {
-                root_mass += pi[i] * root_prof.values[i];
-            }
-            let cat_ll = category.weight.ln() + root_mass.ln() + root_prof.log_scale;
+            // UP pass: shared Felsenstein pruning core (see `prune_pattern_category`).
+            // The profiles are retained here to seed the marginal down pass below.
+            let (profiles, cat_ll) = prune_pattern_category(
+                tree,
+                model,
+                cat_idx,
+                category.weight,
+                pattern,
+                &leaf_id_map,
+                &postord,
+                pi,
+                n_states,
+            )?;
             cat_log_likelihoods.push(cat_ll);
+            let root_prof = profiles.get(&root).unwrap();
 
             // DOWN pass: Pre-order traversal, marginal posteriors for this category.
             let mut node_posteriors: HashMap<NodeID, Vec<f64>> = HashMap::new();

--- a/src/tree/likelihood.rs
+++ b/src/tree/likelihood.rs
@@ -1,13 +1,16 @@
 //! Phylogenetic likelihood under a substitution model.
 //!
-//! Felsenstein's pruning algorithm over a tree and an [`Alignment`], generalized
-//! across the rate categories of a [`GtrModel`].
+//! Felsenstein's pruning algorithm over a tree and an
+//! [`Alignment`](crate::alignment::Alignment), generalized across the rate
+//! categories of a [`GtrModel`](crate::models::GtrModel).
 //!
-//! [`compute_log_likelihood`] returns just the tree's log-likelihood — the
-//! Felsenstein up pass, no ancestral states. [`compute_marginal_asr`] reuses the
-//! same per-pattern pruning core (`prune_pattern_category`) and adds a pre-order
-//! down pass to reconstruct states and posteriors, so the two never drift. The
-//! [`TreeLikelihood`] trait exposes the likelihood-only path.
+//! [`compute_log_likelihood`](crate::tree::likelihood::compute_log_likelihood)
+//! returns just the tree's log-likelihood — the Felsenstein up pass, no ancestral
+//! states. [`compute_marginal_asr`](crate::tree::likelihood::compute_marginal_asr)
+//! reuses the same per-pattern pruning core (`prune_pattern_category`) and adds a
+//! pre-order down pass to reconstruct states and posteriors, so the two never
+//! drift. The [`TreeLikelihood`](crate::tree::likelihood::TreeLikelihood) trait
+//! exposes the likelihood-only path.
 //!
 //! The joint (Viterbi) engine keeps its own recursion: it maximizes rather than
 //! sums over states (a different semiring), so it cannot share the marginal core.
@@ -143,7 +146,7 @@ fn prune_pattern_category<A: Alphabet>(
 ///
 /// Felsenstein's pruning up pass only: for each compressed alignment pattern the
 /// per-category log-likelihoods (`prune_pattern_category`) are mixed with
-/// [`log_sum_exp`] and accumulated by pattern multiplicity. No down pass, and no
+/// `log_sum_exp` and accumulated by pattern multiplicity. No down pass, and no
 /// per-node sequence/posterior allocation — unlike [`compute_marginal_asr`], whose
 /// `log_likelihood` field this reproduces exactly.
 ///

--- a/src/tree/likelihood/integration_test.rs
+++ b/src/tree/likelihood/integration_test.rs
@@ -647,3 +647,60 @@ fn test_profile_log_likelihood_with_scale() {
     // sum(values) = 1.0, ln(1.0) + scale = scale
     assert!((profile.total_log_likelihood() - scale).abs() < 1e-10);
 }
+
+// ===========================================================================
+// TreeLikelihood tests (pruning-only log-likelihood)
+// ===========================================================================
+
+/// The 1a correctness guard: the standalone `log_likelihood` must equal the
+/// `log_likelihood` field produced by full marginal reconstruction, across the
+/// range of model complexity (JC69, HKY85, GTR+G) — proving the shared pruning
+/// core did not change the marginal numbers.
+#[test]
+fn test_log_likelihood_matches_marginal_asr() {
+    let tree = build_tiny_tree();
+    let aln_data =
+        b">A\nACGTACGTACGTACGT\n>B\nAGGTAGGTAGGTAGGT\n>C\nACGTACGTACGTACGT\n>D\nTTTTTTTTTTTTTTTT\n";
+    let aln = Alignment::from_fasta_bytes(aln_data).unwrap();
+
+    let jc69 = GtrModel::<Nucleotide>::jukes_cantor().unwrap();
+    let hky85 = GtrModel::<Nucleotide>::hky85([0.3, 0.2, 0.2, 0.3], 2.5).unwrap();
+    let gtr_g = GtrModel::<Nucleotide>::gtr([0.3, 0.2, 0.2, 0.3], [1.0, 2.5, 1.0, 1.0, 2.5, 1.0])
+        .unwrap()
+        .with_gamma(0.5, 4)
+        .unwrap();
+
+    for model in [jc69, hky85, gtr_g] {
+        let direct = tree.log_likelihood::<Nucleotide>(&model, &aln).unwrap();
+        let via_asr = tree
+            .marginal_asr::<Nucleotide>(&model, &aln, false)
+            .unwrap()
+            .log_likelihood;
+        assert!(
+            (direct - via_asr).abs() < 1e-9,
+            "log_likelihood {direct} != marginal_asr log_likelihood {via_asr}"
+        );
+    }
+}
+
+#[test]
+fn test_log_likelihood_finite() {
+    let tree = build_tiny_tree();
+    let model = GtrModel::<Nucleotide>::jukes_cantor().unwrap();
+    let aln_data = b">A\nACGT\n>B\nAGGT\n>C\nACGT\n>D\nTTTT\n";
+    let aln = Alignment::from_fasta_bytes(aln_data).unwrap();
+
+    let ll = tree.log_likelihood::<Nucleotide>(&model, &aln).unwrap();
+    assert!(ll.is_finite());
+}
+
+#[test]
+fn test_log_likelihood_missing_taxon_errors() {
+    let tree = build_tiny_tree();
+    let model = GtrModel::<Nucleotide>::jukes_cantor().unwrap();
+    // Taxon 'X' is not in the tree, and 'D' is missing.
+    let aln_data = b">A\nACGT\n>B\nAGGT\n>C\nAAAA\n>X\nTTTT\n";
+    let aln = Alignment::from_fasta_bytes(aln_data).unwrap();
+
+    assert!(tree.log_likelihood::<Nucleotide>(&model, &aln).is_err());
+}


### PR DESCRIPTION
## Summary

Compute the log-likelihood of an alignment given a tree and substitution model **without reconstructing ancestral states**.

Previously the number was only reachable via `compute_marginal_asr` / `compute_joint_asr`, which also run a pre-order down pass and allocate per-node sequences/posteriors (`n_nodes × aln.width`) — pure waste for a likelihood query. The module doc called this out as a known seam ("the log-likelihood is only reachable by also reconstructing states").

## Approach (1a: shared core, no third copy)

- Extract the Felsenstein up pass into one shared helper `prune_pattern_category` (per compressed pattern, per rate category → `(profiles, cat_ll)`).
- `compute_log_likelihood` (new) keeps only `cat_ll`, drops the profiles — no down pass, no sequence/posterior allocation.
- `compute_marginal_asr` (refactored) retains the returned profiles to seed its unchanged down pass. **One pruning recursion, not a divergent copy.**
- Joint/Viterbi engine keeps its own recursion (max semiring — cannot share the marginal core).
- New feature-free `TreeLikelihood` trait; concrete `impl` on `PhyloTree` beside `MarginalAsr`/`JointAsr`.

## Usage

```rust
let ll = tree.log_likelihood::<Nucleotide>(&model, &aln)?;
```

## Test plan

- [x] `test_log_likelihood_matches_marginal_asr` — asserts `log_likelihood` equals `marginal_asr(..).log_likelihood` within `1e-9` across JC69, HKY85, and GTR+G (guards the shared-core refactor).
- [x] `test_log_likelihood_finite`, `test_log_likelihood_missing_taxon_errors`.
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features` (exit 0; the 13 warnings are pre-existing `result_unit_err` in `ops.rs`, none in changed files)
- [x] `cargo test` + `cargo test --features parallel`
- [x] `cargo build --no-default-features` (trait compiles feature-free; concrete impl gated off)
- [x] `cargo bench --no-run`

## Out of scope

- Generic-over-`RootedTree` impl (clean follow-up — the up pass only touches trait methods).
- Sharing the joint/Viterbi recursion.
- Any `+I`/`+G` or model API changes.